### PR TITLE
Hotfix/icon send button

### DIFF
--- a/app/ChatRoom.tsx
+++ b/app/ChatRoom.tsx
@@ -166,6 +166,9 @@ const styles = StyleSheet.create({
     backgroundColor: '#F9F9F9',
   },
   sendButton: {
+    width: 32,
+    backgroundColor: '#000000',
+    borderRadius: 100,
     marginLeft: 10,
     marginBottom: 5,
   },

--- a/app/login.tsx
+++ b/app/login.tsx
@@ -11,8 +11,8 @@ export default function LoginScreen() {
   const { users, login } = useAppContext();
   const router = useRouter();
 
-  const handleUserSelect = (userId: string) => {
-    if (login(userId)) {
+  const handleUserSelect = async (userId: string) => {
+    if (await login(userId)) {
       router.replace('/(tabs)');
     }
   };

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -3,7 +3,7 @@
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { SymbolWeight } from 'expo-symbols';
 import React from 'react';
-import { OpaqueColorValue, StyleProp, ViewStyle } from 'react-native';
+import { OpaqueColorValue, StyleProp, TextStyle, ViewStyle } from 'react-native';
 
 // Add your SFSymbol to MaterialIcons mappings here.
 const MAPPING = {
@@ -13,6 +13,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'arrow.up.circle.fill': 'arrow-upward',
 } as Partial<
   Record<
     import('expo-symbols').SymbolViewProps['name'],
@@ -36,7 +37,7 @@ export function IconSymbol({
   name: IconSymbolName;
   size?: number;
   color: string | OpaqueColorValue;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<TextStyle>;
   weight?: SymbolWeight;
 }) {
   return <MaterialIcons color={color} size={size} name={MAPPING[name]} style={style} />;


### PR DESCRIPTION
quick fix for the error in the display of the button to send messages, which prevented the correct use of the application, as the user could not see the send button.